### PR TITLE
[CI-1171] use constant for message attributes

### DIFF
--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -61,7 +61,7 @@ module ActiveJob
         end
 
         msg[:message_body] = body
-        msg[:message_attributes] = MESSAGE_ATTRIBUTES
+        msg[:message_attributes] = MESSAGE_ATTRIBUTES.dup
 
         msg.merge(options)
       end

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -61,22 +61,13 @@ module ActiveJob
         end
 
         msg[:message_body] = body
-        msg[:message_attributes] = message_attributes
+        msg[:message_attributes] = MESSAGE_ATTRIBUTES
 
         msg.merge(options)
       end
 
       def register_worker!(job)
         Shoryuken.register_worker(job.queue_name, JobWrapper)
-      end
-
-      def message_attributes
-        @message_attributes ||= {
-          'shoryuken_class' => {
-            string_value: JobWrapper.to_s,
-            data_type: 'String'
-          }
-        }
       end
 
       class JobWrapper #:nodoc:
@@ -88,6 +79,13 @@ module ActiveJob
           Base.execute hash
         end
       end
+
+      MESSAGE_ATTRIBUTES = {
+        'shoryuken_class' => {
+          string_value: JobWrapper.to_s,
+          data_type: 'String'
+        }
+      }.freeze
     end
   end
 end


### PR DESCRIPTION
Addresses: [CI-1171](https://dripcom.atlassian.net/browse/CI-1171)
Rails side: https://github.com/DripEmail/drip/pull/19068

Co-authored-by: Norma Farah <norma.farah@drip.com>
Co-authored-by: Tamara Temple <tamara.temple@drip.com>

* Instead of memoizing a constant which may or may not be causing grief by inappropriate re-use, just use a constant.

This is an experimental branch to see if we can eliminate the HB from https://dripcom.atlassian.net/browse/CI-1171