### PR TITLE
Allow message attributes to be passed in

### DIFF
--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -53,30 +53,23 @@ module ActiveJob
       def message(queue, job, options = {})
         body = job.serialize
 
-        msg = {}
+        message_attributes = options.delete(:message_attributes) || {}
+
+        msg = {
+          message_body: body,
+          message_attributes: message_attributes.merge(MESSAGE_ATTRIBUTES)
+        }
 
         if queue.fifo?
           # See https://github.com/phstc/shoryuken/issues/457
           msg[:message_deduplication_id] = Digest::SHA256.hexdigest(JSON.dump(body.except('job_id')))
         end
 
-        msg[:message_body] = body
-        msg[:message_attributes] = message_attributes
-
         msg.merge(options)
       end
 
       def register_worker!(job)
         Shoryuken.register_worker(job.queue_name, JobWrapper)
-      end
-
-      def message_attributes
-        @message_attributes ||= {
-          'shoryuken_class' => {
-            string_value: JobWrapper.to_s,
-            data_type: 'String'
-          }
-        }
       end
 
       class JobWrapper #:nodoc:
@@ -88,6 +81,13 @@ module ActiveJob
           Base.execute hash
         end
       end
+
+      MESSAGE_ATTRIBUTES = {
+        'shoryuken_class' => {
+          string_value: JobWrapper.to_s,
+          data_type: 'String'
+        }
+      }.freeze
     end
   end
 end

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -19,6 +19,9 @@ RSpec.shared_examples 'active_job_adapters' do
     specify do
       expect(queue).to receive(:send_message) do |hash|
         expect(hash[:message_deduplication_id]).to_not be
+        expect(hash[:message_attributes]['shoryuken_class'][:string_value]).to eq(described_class::JobWrapper.to_s)
+        expect(hash[:message_attributes]['shoryuken_class'][:data_type]).to eq("String")
+        expect(hash[:message_attributes].keys).to eq(['shoryuken_class'])
       end
       expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
 
@@ -50,7 +53,6 @@ RSpec.shared_examples 'active_job_adapters' do
         }
 
         expect(queue).to receive(:send_message) do |hash|
-          expect(hash[:message_deduplication_id]).to_not be
           expect(hash[:message_attributes]['shoryuken_class'][:string_value]).to eq(described_class::JobWrapper.to_s)
           expect(hash[:message_attributes]['shoryuken_class'][:data_type]).to eq("String")
           expect(hash[:message_attributes]['tracer_id'][:string_value]).to eq(custom_message_attributes['tracer_id'][:string_value])


### PR DESCRIPTION
Related to: https://dripcom.atlassian.net/browse/CI-1171 , #6, https://github.com/DripEmail/drip/pull/19068

When setting the `message_attributes` for SQS, allow passing in and remove memoization of possibly mutated object.

This is a superset of the changes made in #6 .  Basically when writing the test we figured out we'd make it possible to send in custom attributes also since the changes are overlapping and related.